### PR TITLE
Update README.md with hints to podman option 

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,10 @@ The instructions below assume:
             quay.io/agnosticd/ee-multicloud:v0.0.11  \
             ./ansible/install.yaml
 
-            for SE Linux enabled hosts use the Z flag to set the correct SELinux label on the bind mount: 
+            ```
+                        
+            for SE Linux enabled hosts use the Z flag to set the correct SELinux label on the bind mount:
+
             ```sh
             podman run -i -t --rm --entrypoint /usr/local/bin/ansible-playbook \
             -v $PWD:/runner:Z \

--- a/README.md
+++ b/README.md
@@ -100,6 +100,14 @@ The instructions below assume:
             quay.io/agnosticd/ee-multicloud:v0.0.11  \
             ./ansible/install.yaml
 
+            for SE Linux enabled hosts use the Z flag to set the correct SELinux label on the bind mount: 
+            ```sh
+            podman run -i -t --rm --entrypoint /usr/local/bin/ansible-playbook \
+            -v $PWD:/runner:Z \
+            -v $PWD/ansible/kube-demo:/home/runner/.kube/config:Z \
+            quay.io/agnosticd/ee-multicloud:v0.0.11  \
+            ./ansible/install.yaml         
+
             ```
     <br/>
 


### PR DESCRIPTION
hint to use the :Z option to set the correct SELinux label on the bind mount. Otherwise the permissions on the mounted are not set correctly and ansible cannot find the files.

here without the :Z option:
```console
mbastug@fedora:~/Documents/GitHub/sp-edge-to-cloud-data-pipelines-demo$ podman run -i -t --rm --entrypoint /usr/local/bin/ansible-playbook \
-v $PWD:/runner \
-v $PWD/ansible/kube-demo:/home/runner/.kube/config \
quay.io/agnosticd/ee-multicloud:v0.0.11  \
./ansible/install.yaml
ERROR! the playbook: ./ansible/install.yaml could not be found
mbastug@fedora:~/Documents/GitHub/sp-edge-to-cloud-data-pipelines-demo$ sestatus
SELinux status:                 enabled

```

with :Z option set:
```console
mbastug@fedora:~/Documents/GitHub/sp-edge-to-cloud-data-pipelines-demo$ podman run -i -t --rm --entrypoint /usr/local/bin/ansible-playbook -v $PWD:/runner:Z -v $PWD/ansible/kube-demo:/home/runner/.kube/config:Z quay.io/agnosticd/ee-multicloud:v0.0.11  ./ansible/install.yaml
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

PLAY [Install Edge-to-Core Solution Pattern Demo] ********************************************************************************************************************************************************************************************

TASK [Install] *******************************************************************************************************************************************************************************************************************************

TASK [install : Get OpenShift Apps Domain] ***************************************************************************************************************************************************************************************************
/usr/local/lib/python3.9/site-packages/urllib3/connectionpool.py:1045: InsecureRequestWar
```